### PR TITLE
Remove ".vim" from repo name to install with Plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# syntastic-local-solhint.vim
+# syntastic-local-solhint
 
 Prefer local repo install of solhint over global install with syntastic
 
@@ -8,7 +8,7 @@ Installation Instructions
 Using [vim plugged](https://github.com/junegunn/vim-plug) you just need to add:
 
 ```
-Plug 'sohkai/syntastic-local-solhint.vim'
+Plug 'sohkai/syntastic-local-solhint'
 ```
 
 Inspired By


### PR DESCRIPTION
Also removed ".vim" from title of README. That is:

syntastic-local-solhint.vim --> syntastic-local-solhint

Fixes #3